### PR TITLE
validator: allow array in space and command delimited strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/calyptia/go-fluentbit-config/v2
 
-go 1.22
+go 1.22.4
 
 require (
-	github.com/alecthomas/assert/v2 v2.9.0
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
+	github.com/alecthomas/assert/v2 v2.10.0
+	golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-github.com/alecthomas/assert/v2 v2.9.0 h1:ZcLG8ccMEtlMLkLW4gwGpBWBb0N8MUCmsy1lYBVd1xQ=
-github.com/alecthomas/assert/v2 v2.9.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
+github.com/alecthomas/assert/v2 v2.10.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8 h1:LoYXNGAShUG3m/ehNk4iFctuhGX/+R1ZpfJ4/ia80JM=
+golang.org/x/exp v0.0.0-20240604190554-fc45aab8b7f8/go.mod h1:jj3sYF3dwk5D+ghuXyeI3r5MFf+NT2An6/9dOA95KSI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/validator.go
+++ b/validator.go
@@ -202,6 +202,10 @@ func valid(opts SchemaOptions, val any) bool {
 		s, ok := val.(string)
 		return ok && s != ""
 	case "multiple comma delimited strings":
+		if _, ok := val.([]any); ok {
+			return true
+		}
+
 		_, ok := val.(string)
 		return ok
 	case "space delimited strings (minimum 1)":
@@ -294,10 +298,24 @@ func validByteSize(val any) bool {
 }
 
 func validSpaceDelimitedString(val any, min int) bool {
-	s, ok := val.(string)
-	if !ok {
-		return false
+	valid := func(val any, min int) bool {
+		s, ok := val.(string)
+		if !ok {
+			return false
+		}
+
+		return len(strings.Fields(s)) >= min
 	}
 
-	return len(strings.Fields(s)) >= min
+	if v, ok := val.([]any); ok {
+		for _, s := range v {
+			if !valid(s, min) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	return valid(val, min)
 }

--- a/validator.go
+++ b/validator.go
@@ -203,6 +203,12 @@ func valid(opts SchemaOptions, val any) bool {
 		return ok && s != ""
 	case "multiple comma delimited strings":
 		if _, ok := val.([]any); ok {
+			for _, v := range val.([]any) {
+				if _, ok := v.(string); !ok {
+					return false
+				}
+			}
+
 			return true
 		}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -314,6 +314,27 @@ func TestConfig_Validate(t *testing.T) {
 					timeout     5s
 			`,
 		},
+		{
+			name: "out_splunk_event_field",
+			// out_splunk event_field is: space delimited strings (minimum 2)
+			ini: `
+				[OUTPUT]
+					Name        splunk
+					event_field $source foo
+					event_field $vendor bar
+					event_field $product baz
+			`,
+		},
+		{
+			name: "out_stackdriver_labels",
+			// out_stackdriver labels is: multiple comma delimited strings
+			ini: `
+				[OUTPUT]
+					Name   stackdriver
+					labels foo
+					labels bar
+			`,
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
See [shortcut task](https://app.shortcut.com/chronosphere/story/95199/incorrect-rendering-of-map-values-in-the-ui-for-splunk-http-output-plugins).