### PR TITLE
property: fix panic in equality check of property value

### DIFF
--- a/property/property.go
+++ b/property/property.go
@@ -1,6 +1,7 @@
 package property
 
 import (
+	"reflect"
 	"strings"
 
 	"golang.org/x/exp/slices"
@@ -92,7 +93,7 @@ func (pp *Properties) Add(key string, value any) {
 
 func (pp Properties) Equal(target Properties) bool {
 	return slices.EqualFunc(pp, target, func(a, b Property) bool {
-		return a.Key == b.Key && a.Value == b.Value
+		return a.Key == b.Key && reflect.DeepEqual(a.Value, b.Value)
 	})
 }
 

--- a/property/property_test.go
+++ b/property/property_test.go
@@ -1,0 +1,19 @@
+package property
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestProperties_Equal(t *testing.T) {
+	assert.NotPanics(t, func() {
+		p1 := Properties{
+			{Key: "key1", Value: []any{"value1"}},
+		}
+		p2 := Properties{
+			{Key: "key1", Value: []any{"value1"}},
+		}
+		p1.Equal(p2)
+	})
+}


### PR DESCRIPTION
Use `reflect.DeepEqual` to compare `any` instead of `==` that can cause a runtime panic:

```
runtime error: comparing uncomparable type []interface {}
```

[sc-102789]