### PR TITLE
fix: valdiate the service section has only string values [sc-125782].

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -30,6 +30,15 @@ func (c Config) ValidateWithSchema(schema Schema) error {
 		return nil
 	}
 
+	validateService := func(properties property.Properties) error {
+		for _, property := range properties {
+			if _, ok := property.Value.(string); !ok {
+				return fmt.Errorf("illegal service setting: %s", property.Key)
+			}
+		}
+		return nil
+	}
+
 	if err := validate(SectionKindCustom, c.Customs); err != nil {
 		return err
 	}
@@ -43,6 +52,10 @@ func (c Config) ValidateWithSchema(schema Schema) error {
 	}
 
 	if err := validate(SectionKindOutput, c.Pipeline.Outputs); err != nil {
+		return err
+	}
+
+	if err := validateService(c.Service); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
It should be fine to only allow strings in the `[SERVICE]` section since the event based yaml parser also does not allow either arrays or mappings under the `service` section.

I tested this empirically using a yaml file with bothing an array and a mapping in it:

```yaml
service:
  parser:
    - one
    - two
```

The result:
```
╭─pwhelan@Phillips-MacBook-Pro ~/Projects/work/fluent-bit.git/master ‹master●›
╰─$ ./build/bin/fluent-bit -c build/test.yaml
Fluent Bit v4.0.1
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/04/16 13:27:22] [error] [config] YAML error found in file "build/test.yaml", line 5, column 4: unexpected event 'sequence-start-event' (7) in state 'section-value' (5).
[2025/04/16 13:27:22] [error] yaml error
[2025/04/16 13:27:22] [error] configuration file contains errors, aborting.
```

And a mapping:

```yaml
service:
  parser:
    one: two
```

```
╭─pwhelan@Phillips-MacBook-Pro ~/Projects/work/fluent-bit.git/master ‹master●›
╰─$ ./build/bin/fluent-bit -c build/test.yaml
Fluent Bit v4.0.1
* Copyright (C) 2015-2025 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

______ _                  _    ______ _ _             ___  _____
|  ___| |                | |   | ___ (_) |           /   ||  _  |
| |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __/ /| || |/' |
|  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / / /_| ||  /| |
| |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /\___  |\ |_/ /
\_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/     |_(_)___/


[2025/04/16 13:27:56] [error] [config] YAML error found in file "build/test.yaml", line 5, column 4: unexpected event 'mapping-start-event' (9) in state 'section-value' (5).
[2025/04/16 13:27:56] [error] yaml error
[2025/04/16 13:27:56] [error] configuration file contains errors, aborting.
```

I also checked the code [src/config_format/flb_cf_yaml.c](https://github.com/fluent/fluent-bit/blob/7636151cd27353ffeaf606e516c95d567beaa77a/src/config_format/flb_cf_yaml.c#L1702):

```c
    case STATE_SECTION_KEY:
        switch(event->type) {
        case YAML_SCALAR_EVENT:
            value = (char *) event->data.scalar.value;
            state = state_push_key(ctx, STATE_SECTION_VAL, value);
....
    case YAML_MAPPING_END_EVENT:
            state = state_pop(ctx);
            switch (state->state) {
            case STATE_SERVICE:
            case STATE_ENV:
            case STATE_OTHER:
                break;
            default:
                printf("BAD STATE FOR SECTION KEY POP=%s\n", state_str(state->state));
                yaml_error_event(ctx, state, event);
                return YAML_FAILURE;
            }
```
