### PR TITLE
fix: add support for booleans, integers, floats and strings for service settings [sc-125782].

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -32,7 +32,13 @@ func (c Config) ValidateWithSchema(schema Schema) error {
 
 	validateService := func(properties property.Properties) error {
 		for _, property := range properties {
-			if _, ok := property.Value.(string); !ok {
+			switch property.Value.(type) {
+			case bool:
+			case int:
+			case int64:
+			case float64:
+			case string:
+			default:
 				return fmt.Errorf("illegal service setting: %s", property.Key)
 			}
 		}

--- a/validator_test.go
+++ b/validator_test.go
@@ -424,6 +424,42 @@ func TestConfig_Validate_Schema_YAML(t *testing.T) {
 			`),
 			want: "illegal service setting: headers",
 		},
+		// it does support booleans
+		{
+			name: "service_with_http_server",
+			yaml: configLiteral(`
+				service:
+					http_server: true
+			`),
+			want: "",
+		},
+		// integers
+		{
+			name: "service_with_http_port",
+			yaml: configLiteral(`
+				service:
+					http_port: 2020
+			`),
+			want: "",
+		},
+		// and strings
+		{
+			name: "service_with_string_setting",
+			yaml: configLiteral(`
+				service:
+					label: FOOBAR
+			`),
+			want: "",
+		},
+		// and floating point
+		{
+			name: "service_with_flush_microseconds",
+			yaml: configLiteral(`
+				service:
+					flush: 0.2
+			`),
+			want: "",
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Add missing support for other types in service settings. This is necessary to support at least the following typical service settings:

- http_server
- http_port
- flush (with microseconds)

Tests have also been added to make sure maps and slices still fail but the simple types pass.