### PR TITLE
fix: revert overwriting the embed for all the schema files.

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-//go:embed schemas/25.4.3.json
+//go:embed schemas/*.json
 var rawSchemas embed.FS
 //go:embed schemas/25.4.3.json
 var rawSchema []byte


### PR DESCRIPTION
Revert the clobbering from core-image-index, depends upon: https://github.com/chronosphereio/calyptia-core-index/pull/423. If it is not merged this will get clobbered again eventually.