### PR TITLE
bug: Update azure-blob-input schema validation to match go plugin [sc-132735]

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -12,6 +12,7 @@ import (
 
 //go:embed schemas/*.json
 var rawSchemas embed.FS
+
 //go:embed schemas/25.5.1.json
 var rawSchema []byte
 
@@ -498,9 +499,9 @@ func (s *Schema) InjectLTSPlugins() {
 			},
 		},
 	}, SchemaSection{
-		// See https://github.com/chronosphereio/calyptia-core-fluent-bit-azure-blob-input
+		// See https://github.com/chronosphereio/calyptia-core-fluent-bit/tree/main/goplugins/azure-blob-input
 		Type:        "input",
-		Name:        "flb_core_fluent_bit_azure_blob",
+		Name:        "azure-blob-input",
 		Description: "Calyptia LTS Azure Blob Storage Input Plugin",
 		Properties: SchemaProperties{
 			Options: []SchemaOptions{
@@ -510,14 +511,24 @@ func (s *Schema) InjectLTSPlugins() {
 					Description: "Azure Storage Account Name",
 				},
 				{
+					Name:        "connection_string",
+					Type:        "string",
+					Description: "A connection string provides all the necessary information to connect to an Azure Storage account. If provided, it will be used for authentication instead of the default credential-based method.",
+				},
+				{
 					Name:        "container",
 					Type:        "string",
 					Description: "If set, the plugin will only read from this container. Otherwise, it will read from all containers in the account.",
 				},
 				{
-					Name:        "bucket",
+					Name:        "service_url",
 					Type:        "string",
-					Description: "-",
+					Description: "The service URL for the Azure Blob Storage endpoint. If not specified, it defaults to 'https://<account_name>.blob.core.windows.net'.",
+				},
+				{
+					Name:        "tenant_id",
+					Type:        "string",
+					Description: "The Azure Active Directory (AAD) tenant ID to use for authentication. This is used with the 'DefaultAzureCredential' to authenticate requests when a connection string is not provided.",
 				},
 			},
 		},

--- a/validator_test.go
+++ b/validator_test.go
@@ -460,6 +460,31 @@ func TestConfig_Validate_Schema_YAML(t *testing.T) {
 			`),
 			want: "",
 		},
+		{
+			name: "input_azure_blob_input_correct",
+			yaml: configLiteral(`
+			pipeline:
+				inputs:
+					- name: azure-blob-input
+					  tag: blob
+					  account_name: test_account
+					  connection_string: "DefaultEndpointsProtocol=http;AccountName=test_account;AccountKey=foo;BlobEndpoint=http://127.0.0.1:10000/test_account;"
+					  container: test_container
+					  service_url: test_service_url
+					  tenant_id: test_tenant_id
+			`),
+			want: "",
+		},
+		{
+			name: "input_azure_blob_input_incorrect_key",
+			yaml: configLiteral(`
+			pipeline:
+				inputs:
+					- name: azure-blob-input
+					  incorrect_key: foo
+			`),
+			want: "input: azure-blob-input: unknown property \"incorrect_key\"",
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Also removes `bucket` since it isn't read in the plugin. 

In a future PR I plan to go through the rest of the go plugins and update schema.go as needed.