### PR TITLE
feat: add support for the calyptia processor when validating schemas.

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -979,33 +979,33 @@ func (s *Schema) InjectLTSPlugins() {
 	}) // Keep these alphabatized instead of adding new sections at the end.
 
 	s.Processors = append(s.Processors, SchemaSection{
-		Type: "processor",
-		Name: "calyptia",
+		Type:        "processor",
+		Name:        "calyptia",
 		Description: "calyptia actions processor",
 		Properties: SchemaProperties{
 			Options: []SchemaOptions{{
-				Name: "actions",
-				Type: "multiple keyvalues",
+				Name:        "actions",
+				Type:        "multiple keyvalues",
 				Description: "calyptia actions to effect",
 				Options: SchemaOptionList{
 					{
-						Name: "type",
-						Type: "string",
+						Name:        "type",
+						Type:        "string",
 						Description: "the type of the action",
 					},
 					{
-						Name: "opts",
-						Type: "keyvalue",
+						Name:        "opts",
+						Type:        "keyvalue",
 						Description: "action arguments",
 					},
 					{
-						Name: "condition",
-						Type: "keyvalue",
+						Name:        "condition",
+						Type:        "keyvalue",
 						Description: "conditionals for the action to be effected",
 						Options: SchemaOptionList{
 							{
-								Name: "operator",
-								Type: "string",
+								Name:        "operator",
+								Type:        "string",
 								Description: "conditional operator, one of AND/OR",
 							},
 							{
@@ -1013,22 +1013,22 @@ func (s *Schema) InjectLTSPlugins() {
 								Type: "multiple keyvalue",
 								Options: SchemaOptionList{
 									{
-										Name: "field",
-										Type: "string",
+										Name:        "field",
+										Type:        "string",
 										Description: "the field to compare",
 									},
 									{
-										Name: "operator",
-										Type: "string",
+										Name:        "operator",
+										Type:        "string",
 										Description: "operator, one of eq, neq, gt, gte, lt, lte, regex, not_regex, in or not_in",
 									},
 									{
-										Name: "value",
+										Name:        "value",
 										Description: "the value to compare against",
 									},
 									{
-										Name: "context",
-										Type: "string",
+										Name:        "context",
+										Type:        "string",
 										Description: "the context to compare in, set to metadata to compare against record metadata",
 									},
 								},

--- a/schema.go
+++ b/schema.go
@@ -148,7 +148,7 @@ func (s Schema) findSections(kind SectionKind) ([]SchemaSection, bool) {
 	case SectionKindOutput:
 		return s.Outputs, true
 	case SectionKindProcessor:
-		return s.Processors, true
+		return append(s.Processors, s.Filters...), true
 	default:
 		return nil, false
 	}

--- a/section.go
+++ b/section.go
@@ -5,10 +5,11 @@ type SectionKind string
 func (k SectionKind) String() string { return string(k) }
 
 const (
-	SectionKindService SectionKind = "service"
-	SectionKindCustom  SectionKind = "custom"
-	SectionKindInput   SectionKind = "input"
-	SectionKindParser  SectionKind = "parser"
-	SectionKindFilter  SectionKind = "filter"
-	SectionKindOutput  SectionKind = "output"
+	SectionKindService   SectionKind = "service"
+	SectionKindCustom    SectionKind = "custom"
+	SectionKindInput     SectionKind = "input"
+	SectionKindParser    SectionKind = "parser"
+	SectionKindFilter    SectionKind = "filter"
+	SectionKindOutput    SectionKind = "output"
+	SectionKindProcessor SectionKind = "processor"
 )

--- a/testdata/processors/calyptia_processor.json
+++ b/testdata/processors/calyptia_processor.json
@@ -1,0 +1,49 @@
+{
+    "service": {
+        "log_level": "info",
+        "http_server": "on",
+        "http_listen": "0.0.0.0",
+        "http_port": 2021
+    },
+    "pipeline": {
+        "inputs": [
+            {
+                "name": "dummy",
+                "tag": "test-tag",
+                "processors": {
+                    "logs": [
+                        {
+                            "actions": [
+                                {
+                                    "condition": {
+                                        "operator": "AND",
+                                        "rules": [
+                                            {
+                                                "field": "foo",
+                                                "operator": "eq",
+                                                "value": "bar"
+                                            }
+                                        ]
+                                    },
+                                    "opts": {
+                                        "key": "foo",
+                                        "value": "bar"
+                                    },
+                                    "type": "put"
+                                }
+                            ],
+                            "name": "calyptia"
+                        }
+                    ]
+                }
+            }
+        ],
+        "outputs": [
+            {
+                "name": "stdout",
+                "format": "json_lines",
+                "match": "*"
+            }
+        ]
+    }
+}

--- a/testdata/processors/calyptia_processor.yaml
+++ b/testdata/processors/calyptia_processor.yaml
@@ -1,0 +1,27 @@
+service:
+    log_level: info
+    http_server: "on"
+    http_listen: 0.0.0.0
+    http_port: 2021
+pipeline:
+    inputs:
+        - name: dummy
+          tag: test-tag
+          processors:
+            logs:
+                - actions:
+                    - condition:
+                        operator: AND
+                        rules:
+                            - field: foo
+                              operator: eq
+                              value: bar
+                      opts:
+                        key: foo
+                        value: bar
+                      type: put
+                  name: calyptia
+    outputs:
+        - name: stdout
+          format: json_lines
+          match: '*'

--- a/validator.go
+++ b/validator.go
@@ -168,7 +168,7 @@ func validateProcessorsSectionMaps(sectionMaps []interface{}) error {
 		for key, val := range section.(map[string]interface{}) {
 			props.Set(key, val)
 		}
-		if err := ValidateSection(SectionKindFilter, props); err != nil {
+		if err := ValidateSection(SectionKindProcessor, props); err != nil {
 			return err
 		}
 
@@ -250,6 +250,10 @@ func valid(opts SchemaOptions, val any) bool {
 		return validSpaceDelimitedString(val, 3)
 	case "space delimited strings (minimum 4)":
 		return validSpaceDelimitedString(val, 4)
+	case "multiple keyvalues":
+		return validArray(val, opts.Options)
+	case "keyvalue":
+		return validKeyValue(val, opts.Options)
 	}
 
 	// valid by default
@@ -352,4 +356,50 @@ func validSpaceDelimitedString(val any, min int) bool {
 	}
 
 	return valid(val, min)
+}
+
+func validArray(val any, options SchemaOptionList) bool {
+	if val == nil {
+		return true
+	}
+
+	keyvalues, ok := val.([]any)
+	if !ok {
+		return false
+	}
+
+	for _, keyvalue := range keyvalues {
+		if !validKeyValue(keyvalue, options) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func validKeyValue(val any, options SchemaOptionList) bool {
+	if val == nil {
+		return true
+	}
+
+	keyval, ok := val.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	if len(options) == 0 {
+		return true
+	}
+
+	for key, val := range keyval {
+		option := options.FindOption(key)
+		if option == nil {
+			return false
+		}
+		if !valid(*option, val) {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
Add the missing support for the calyptia processor in the schema using InjectLTSPlugins. This should allow for the correct validation of pipeline configurations used in the chronosphere pipelines.